### PR TITLE
act_shared_auth_ui: mixin_auth_redirect pop all pages upon event - Refs: #19632

### DIFF
--- a/act_shared_auth_ui/lib/src/services/mixin_auth_redirect_service.dart
+++ b/act_shared_auth_ui/lib/src/services/mixin_auth_redirect_service.dart
@@ -73,10 +73,7 @@ mixin MixinAuthRedirectService<T extends MixinAuthRoute> on MixinRedirectService
       return;
     }
 
-    await routerManager.push(
-      _signInRoute,
-      extra: SignInPageExtra<T>(),
-    );
+    unawaited(routerManager.pushAndRemoveUntilFirstRoute(_signInRoute));
   }
 
   /// This method is called when we want to go to a specific view and ask if it's ok or if we want


### PR DESCRIPTION
If MixinAuthRedirectService detects a sign out, it pop all pages and show SignIn page instead of simply pushing SignInPage over current page.

This is maybe not perfect but this appears a reasonable workaround for routeManager concurrency issue between app trying to pop all and this mixin trying to push over.