### PR TITLE
act_ffi_utility: downgrade flutter SDK requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ SPDX-License-Identifier: LicenseRef-ALLCircuits-ACT-1.1
 
 - [Table of contents](#table-of-contents)
 - [Presentation](#presentation)
-- [Targetted flutter / Dart SDK](#targetted-flutter--dart-sdk)
 - [mono\_repo](#mono_repo)
 - [Packages list](#packages-list)
 - [How to use the packages in your project](#how-to-use-the-packages-in-your-project)
@@ -19,14 +18,6 @@ SPDX-License-Identifier: LicenseRef-ALLCircuits-ACT-1.1
 ## Presentation
 
 Shared flutter packages for all the Flutter projects.
-
-## Targetted flutter / Dart SDK
-
-For compatibility with various projects, packages requiring a minimal Flutter/Dart SDK version
-currently targets:
-
-- a Flutter SDK no more recent than 3.35.3
-- that is a Dart SDK no more recent than 3.9.2
 
 ## mono_repo
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ SPDX-License-Identifier: LicenseRef-ALLCircuits-ACT-1.1
 
 - [Table of contents](#table-of-contents)
 - [Presentation](#presentation)
+- [Targetted flutter / Dart SDK](#targetted-flutter--dart-sdk)
 - [mono\_repo](#mono_repo)
 - [Packages list](#packages-list)
 - [How to use the packages in your project](#how-to-use-the-packages-in-your-project)
@@ -18,6 +19,14 @@ SPDX-License-Identifier: LicenseRef-ALLCircuits-ACT-1.1
 ## Presentation
 
 Shared flutter packages for all the Flutter projects.
+
+## Targetted flutter / Dart SDK
+
+For compatibility with various projects, packages requiring a minimal Flutter/Dart SDK version
+currently targets:
+
+- a Flutter SDK no more recent than 3.35.3
+- that is a Dart SDK no more recent than 3.9.2
 
 ## mono_repo
 

--- a/act_ffi_utility/pubspec.yaml
+++ b/act_ffi_utility/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
   windows:
 
 environment:
-  sdk: ^3.10.1
+  sdk: ^3.9.2
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
flutter pub get fails on older projects running flutter 3.38.2-, due to act_ffi_utility requirement of dart SDK 3.10.1+.

Release this requirement to match more commonly used requirement, making actlib compatible again with Flutter 3.35.3+

refs #83